### PR TITLE
Update to Swift beta 3

### DIFF
--- a/StateRestorationDemo/CityViewController.swift
+++ b/StateRestorationDemo/CityViewController.swift
@@ -18,7 +18,7 @@ class CityViewController: UIViewController, UIViewControllerRestoration, UIState
     init(cityName: String) {
         self.cityName = cityName
         super.init(nibName: nil, bundle: nil)
-        restorationIdentifier = NSString(CString: object_getClassName(self))
+        restorationIdentifier = String.fromCString(object_getClassName(self))
         restorationClass = object_getClass(self)
     }
 
@@ -30,7 +30,7 @@ class CityViewController: UIViewController, UIViewControllerRestoration, UIState
         }
     }
 
-    class func viewControllerWithRestorationIdentifierPath(identifierComponents: AnyObject[]!, coder: NSCoder!) -> UIViewController! {
+    class func viewControllerWithRestorationIdentifierPath(identifierComponents: [AnyObject]!, coder: NSCoder!) -> UIViewController! {
         return CityViewController(cityName: "")
     }
 

--- a/StateRestorationDemo/FirstViewController.swift
+++ b/StateRestorationDemo/FirstViewController.swift
@@ -15,7 +15,7 @@ class FirstViewController: UIViewController, UIStateRestoring {
     init() {
         super.init(nibName: nil, bundle: nil)
         tabBarItem = UITabBarItem(title: "First", image: UIImage(named: "first"), tag: 0)
-        restorationIdentifier = NSString(CString: object_getClassName(self))
+        restorationIdentifier = String.fromCString(object_getClassName(self))
     }
 
     override func encodeRestorableStateWithCoder(coder: NSCoder!)  {

--- a/StateRestorationDemo/SecondViewController.swift
+++ b/StateRestorationDemo/SecondViewController.swift
@@ -18,7 +18,7 @@ class SecondViewController: UIViewController, UIStateRestoring {
     init() {
         super.init(nibName: nil, bundle: nil)
         tabBarItem = UITabBarItem(title: "Second", image: UIImage(named: "second"), tag: 0)
-        restorationIdentifier = NSString(CString: object_getClassName(self))
+        restorationIdentifier = String.fromCString(object_getClassName(self))
     }
 
     override func viewDidLoad() {


### PR DESCRIPTION
- changes array definitions from Class[] to [Class]
- replaces deprecated NSString(CString:) to String.fromCString(cs:)
